### PR TITLE
chore: add token with permissions to update version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The automated update for the version of the repository wasn't working properly due to a missing access token. This PR should fix it.