### PR TITLE
fix: replace placeholder urls

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,14 +1,38 @@
 {
   "types": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "chore", "hidden": true},
-    {"type": "docs", "hidden": true},
-    {"type": "style", "hidden": true},
-    {"type": "refactor", "hidden": true},
-    {"type": "perf", "hidden": true},
-    {"type": "test", "hidden": true}
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "chore",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "hidden": true
+    },
+    {
+      "type": "perf",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "hidden": true
+    }
   ],
-  "commitUrlFormat": "https://github.com/your-username/your-repo/commit/{{hash}}",
-  "compareUrlFormat": "https://github.com/your-username/your-repo/compare/{{previousTag}}...{{currentTag}}"
+  "commitUrlFormat": "https://github.com/hannasdev/team-health-dashboard/commit/{{hash}}",
+  "compareUrlFormat": "https://github.com/hannasdev/team-health-dashboard/compare/{{previousTag}}...{{currentTag}}"
 }


### PR DESCRIPTION
The URLs for the changelog used the template URLs, and they are here and have been replaced with the correct URLs.